### PR TITLE
Fixes errors scrapping author url

### DIFF
--- a/lib/video_info/providers/tedx.rb
+++ b/lib/video_info/providers/tedx.rb
@@ -82,7 +82,7 @@ class VideoInfo
         data[:description] = doc.at("meta[name='description']").try('[]', 'content')
         data[:author] = doc.at("meta[name='author']").try('[]', 'content')
         data[:author_thumbnail] = doc.at("link[itemprop='image']").try('[]', 'href')
-        data[:author_url] = 'https://www.ted.com/' + doc.at("link[itemprop='url']").try('[]', 'href')
+        data[:author_url] = author_url_for(doc.at("link[itemprop='url']").try('[]', 'href'))
         data[:duration] = doc.at("meta[property='og:video:duration']").try('[]', 'content')
         data[:embed_url] = doc.at("link[itemprop='embedURL']").try('[]', 'href')
         data[:cover] = doc.at("link[itemprop='thumbnailUrl']").try('[]', 'content').split('?').first
@@ -95,6 +95,12 @@ class VideoInfo
 
       def _default_url_attributes
         {}
+      end
+
+      def author_url_for(data)
+        return '' if data.nil?
+        return "https://www.ted.com/#{doc.at("link[itemprop='url']").try('[]', 'href')}" unless data.starts_with?('https://www.ted.com')
+        data
       end
     end
   end

--- a/lib/video_info/providers/tedx.rb
+++ b/lib/video_info/providers/tedx.rb
@@ -99,7 +99,7 @@ class VideoInfo
 
       def author_url_for(data)
         return '' if data.nil?
-        return "https://www.ted.com/#{doc.at("link[itemprop='url']").try('[]', 'href')}" unless data.starts_with?('https://www.ted.com')
+        return "https://www.ted.com/#{data}" unless data.starts_with?('https://www.ted.com')
         data
       end
     end

--- a/lib/video_info/version.rb
+++ b/lib/video_info/version.rb
@@ -1,3 +1,3 @@
 class VideoInfo
-  VERSION = '2.7'.freeze
+  VERSION = '2.7.1'.freeze
 end

--- a/spec/lib/video_info/providers/tedx_spec.rb
+++ b/spec/lib/video_info/providers/tedx_spec.rb
@@ -1,0 +1,103 @@
+require 'spec_helper'
+
+describe VideoInfo::Providers::Tedx do
+  describe 'with video https://www.ted.com/talks/mariana_atencio_what_makes_you_special' do
+    subject(:video_info) { VideoInfo.new(url) }
+
+    let(:url) { 'https://www.ted.com/talks/mariana_atencio_what_makes_you_special' }
+
+    describe '#provider' do
+      subject { super().provider }
+      it { is_expected.to eq 'Tedx' }
+    end
+
+    describe '#url' do
+      subject { super().url }
+      it { is_expected.to eq url }
+    end
+
+    describe '#title' do
+      subject { super().title }
+      it { is_expected.to eq 'Mariana Atencio: What makes you special?' }
+    end
+
+    describe '#description' do
+      subject { super().description }
+
+      let(:description) do
+        'When journalist Mariana Atencio was seven, her father sent her from her '\
+        'home in Venezuela to a summer camp in Brainerd, Minnesota. Unsurprisingly, '\
+        'she was treated like an outsider. Over the course of many more such camps '\
+        'and a senior year in an American high school, she discovered that the best '\
+        'way to belong was to embrace the qualities that made her different. In this '\
+        'deeply personal talk, Atencio describes how these early lessons helped her '\
+        'succeed as an immigrant and as a journalist.'
+      end
+
+      it { is_expected.to eq description }
+    end
+
+    describe '#duration' do
+      subject { super().duration }
+      it { is_expected.to eq '0' }
+    end
+
+    describe '#thumbnail_small' do
+      subject { super().thumbnail_small }
+
+      let(:thumbnail_url) do
+        'https://pi.tedcdn.com/r/talkstar-photos.s3.amazonaws.com/uploads/8733af45-0518-4c58-b451-d926d3fa08f1/MarianaAtencio.jpeg?quality=95&w=120'
+      end
+
+      it { is_expected.to eq thumbnail_url }
+    end
+
+    describe '#thumbnail_medium' do
+      subject { super().thumbnail_medium }
+      
+      let(:thumbnail_url) do
+        'https://pi.tedcdn.com/r/talkstar-photos.s3.amazonaws.com/uploads/8733af45-0518-4c58-b451-d926d3fa08f1/MarianaAtencio.jpeg?quality=95&w=480'
+      end
+
+      it { is_expected.to eq thumbnail_url }
+    end
+
+    describe '#thumbnail_large' do
+      subject { super().thumbnail_large }
+      
+      let(:thumbnail_url) do
+        'https://pi.tedcdn.com/r/talkstar-photos.s3.amazonaws.com/uploads/8733af45-0518-4c58-b451-d926d3fa08f1/MarianaAtencio.jpeg'
+      end
+
+      it { is_expected.to eq thumbnail_url }
+    end
+
+    describe '#thumbnail' do
+      subject { super().thumbnail }
+      
+      let(:thumbnail_url) do
+        'https://pi.tedcdn.com/r/talkstar-photos.s3.amazonaws.com/uploads/8733af45-0518-4c58-b451-d926d3fa08f1/MarianaAtencio.jpeg'
+      end
+
+      it { is_expected.to eq thumbnail_url }
+    end
+
+    describe '#author_thumbnail' do
+      subject { super().author_thumbnail }
+
+      let(:thumbnail_url) { '' }
+
+      it { is_expected.to eq thumbnail_url }
+    end
+
+    describe '#author' do
+      subject { super().author }
+      it { is_expected.to eq 'Mariana Atencio' }
+    end
+
+    describe '#author_url' do
+      subject { super().author_url }
+      it { is_expected.to eq 'https://www.ted.com/talks/mariana_atencio_what_makes_you_special' }
+    end
+  end
+end


### PR DESCRIPTION
From https://gitlab.com/neurok/neurok/issues/1336

Tedx provider fails to compose the author url when the information scrapped is nil. In addition, sometimes the prefix 'https://www.etd.com' is not required because it is already contained in the information scrapped.